### PR TITLE
Add gitattributes, ignore the coverage folder for language detection. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+coverage/* linguist-vendored


### PR DESCRIPTION
This will prevent this repo being labeled as HTML.

![Screen Shot 2019-09-05 at 11 05 17 AM](https://user-images.githubusercontent.com/7351329/64355367-16d8d600-cfcf-11e9-9d2b-30c1d41c88f0.png)
